### PR TITLE
Reduce the size of CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,13 @@ set(CMAKE_CXX_STANDARD 17)
 #
 ########################################################
 
+find_package(LLVM 9.0.0 REQUIRED)
+
 set(KAPRINO_MONOTONE_LOG OFF CACHE BOOL "Make stdout monotone")
 set(KAPRINO_OPTIMIZER_ON OFF CACHE BOOL "Optimize output")
 set(KAPRINO_EMIT_LLVM_IR_ONLY OFF CACHE BOOL "Generate LLVM IR and finish program")
 set(ANTLR4_IncludePath "" CACHE STRING "ANTLR4 include files")
 set(ANTLR4_LibPath "" CACHE STRING "ANTLR4 library files")
-set(LLVM_IncludePath "" CACHE STRING "LLVM include files")
-set(LLVM_LibPath "" CACHE STRING "LLVM library files")
 
 ########################################################
 #
@@ -31,16 +31,6 @@ endif()
 
 if ("" STREQUAL "${ANTLR4_LibPath}")
     message(FATAL_ERROR "[Error] Required \${ANTLR4_LibPath} but not applied")
-    return()
-endif()
-
-if ("" STREQUAL "${LLVM_IncludePath}")
-    message(FATAL_ERROR "[Error] Required \${LLVM_IncludePath} but not applied")
-    return()
-endif()
-
-if ("" STREQUAL "${LLVM_LibPath}")
-    message(FATAL_ERROR "[Error] Required \${LLVM_LibPath} but not applied")
     return()
 endif()
 
@@ -124,7 +114,7 @@ add_custom_command(
 add_executable(kprc ${INTERPRETER_SOURCES} ${PARSER_SOURCES})
 
 target_include_directories(kprc PRIVATE ${ANTLR4_IncludePath})
-target_include_directories(kprc PRIVATE ${LLVM_IncludePath})
+target_include_directories(kprc PRIVATE ${LLVM_INCLUDE_DIRS})
 
 if(UNIX)
     target_compile_options(kprc PRIVATE -frtti)
@@ -157,149 +147,9 @@ endif()
 #
 ########################################################
 
-target_link_directories(kprc PUBLIC ${LLVM_LibPath})
-target_link_libraries(kprc
-    LLVMXRay
-    LLVMWindowsManifest
-    LLVMTextAPI
-    LLVMTableGen
-    LLVMSymbolize
-    LLVMDebugInfoPDB
-    LLVMOrcJIT
-    LLVMJITLink
-    LLVMObjectYAML
-    LLVMMCA
-    LLVMLTO
-    LLVMPasses
-    LLVMObjCARCOpts
-    LLVMLineEditor
-    LLVMLibDriver
-    LLVMInterpreter
-    LLVMFuzzMutate
-    LLVMMCJIT
-    LLVMExecutionEngine
-    LLVMRuntimeDyld
-    LLVMDlltoolDriver
-    LLVMOption
-    LLVMDebugInfoGSYM
-    LLVMCoverage
-    LLVMCoroutines
-    LLVMXCoreDisassembler
-    LLVMXCoreCodeGen
-    LLVMXCoreDesc
-    LLVMXCoreInfo
-    LLVMX86Disassembler
-    LLVMX86AsmParser
-    LLVMX86CodeGen
-    LLVMX86Desc
-    LLVMX86Utils
-    LLVMX86Info
-    LLVMWebAssemblyDisassembler
-    LLVMWebAssemblyCodeGen
-    LLVMWebAssemblyDesc
-    LLVMWebAssemblyAsmParser
-    LLVMWebAssemblyInfo
-    LLVMSystemZDisassembler
-    LLVMSystemZCodeGen
-    LLVMSystemZAsmParser
-    LLVMSystemZDesc
-    LLVMSystemZInfo
-    LLVMSparcDisassembler
-    LLVMSparcCodeGen
-    LLVMSparcAsmParser
-    LLVMSparcDesc
-    LLVMSparcInfo
-    LLVMRISCVDisassembler
-    LLVMRISCVCodeGen
-    LLVMRISCVAsmParser
-    LLVMRISCVDesc
-    LLVMRISCVUtils
-    LLVMRISCVInfo
-    LLVMPowerPCDisassembler
-    LLVMPowerPCCodeGen
-    LLVMPowerPCAsmParser
-    LLVMPowerPCDesc
-    LLVMPowerPCInfo
-    LLVMNVPTXCodeGen
-    LLVMNVPTXDesc
-    LLVMNVPTXInfo
-    LLVMMSP430Disassembler
-    LLVMMSP430CodeGen
-    LLVMMSP430AsmParser
-    LLVMMSP430Desc
-    LLVMMSP430Info
-    LLVMMipsDisassembler
-    LLVMMipsCodeGen
-    LLVMMipsAsmParser
-    LLVMMipsDesc
-    LLVMMipsInfo
-    LLVMLanaiDisassembler
-    LLVMLanaiCodeGen
-    LLVMLanaiAsmParser
-    LLVMLanaiDesc
-    LLVMLanaiInfo
-    LLVMHexagonDisassembler
-    LLVMHexagonCodeGen
-    LLVMHexagonAsmParser
-    LLVMHexagonDesc
-    LLVMHexagonInfo
-    LLVMBPFDisassembler
-    LLVMBPFCodeGen
-    LLVMBPFAsmParser
-    LLVMBPFDesc
-    LLVMBPFInfo
-    LLVMARMDisassembler
-    LLVMARMCodeGen
-    LLVMARMAsmParser
-    LLVMARMDesc
-    LLVMARMUtils
-    LLVMARMInfo
-    LLVMAMDGPUDisassembler
-    LLVMAMDGPUCodeGen
-    LLVMMIRParser
-    LLVMipo
-    LLVMInstrumentation
-    LLVMVectorize
-    LLVMLinker
-    LLVMIRReader
-    LLVMAsmParser
-    LLVMAMDGPUAsmParser
-    LLVMAMDGPUDesc
-    LLVMAMDGPUUtils
-    LLVMAMDGPUInfo
-    LLVMAArch64Disassembler
-    LLVMMCDisassembler
-    LLVMAArch64CodeGen
-    LLVMGlobalISel
-    LLVMSelectionDAG
-    LLVMAsmPrinter
-    LLVMDebugInfoDWARF
-    LLVMCodeGen
-    LLVMTarget
-    LLVMScalarOpts
-    LLVMInstCombine
-    LLVMAggressiveInstCombine
-    LLVMTransformUtils
-    LLVMBitWriter
-    LLVMAnalysis
-    LLVMProfileData
-    LLVMObject
-    LLVMBitReader
-    LLVMBitstreamReader
-    LLVMCore
-    LLVMRemarks
-    LLVMAArch64AsmParser
-    LLVMMCParser
-    LLVMAArch64Desc
-    LLVMMC
-    LLVMDebugInfoCodeView
-    LLVMDebugInfoMSF
-    LLVMBinaryFormat
-    LLVMAArch64Utils
-    LLVMAArch64Info
-    LLVMSupport
-    LLVMDemangle
-)
+llvm_map_components_to_libnames(LLVM_LIBS all)
+target_link_directories(kprc PUBLIC ${LLVM_LIBRARY_DIRS})
+target_link_libraries(kprc ${LLVM_LIBS})
 
 ########################################################
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(kaprino VERSION 1.0)
+project(kaprino VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -129,6 +129,10 @@ target_include_directories(kprc PRIVATE ${LLVM_IncludePath})
 if(UNIX)
     target_compile_options(kprc PRIVATE -frtti)
 endif()
+
+target_compile_definitions(kprc
+    PRIVATE KAPRINO_VERSION=\"${kaprino_VERSION}\"
+)
 
 ########################################################
 #

--- a/src/interpreter/KaprinoParser.impl.cpp
+++ b/src/interpreter/KaprinoParser.impl.cpp
@@ -12,6 +12,10 @@
 
 using namespace antlr4;
 
+#ifndef KAPRINO_VERSION
+#define KAPRINO_VERSION "0.0.0"
+#endif
+
 std::vector<StatementObject*>* ParseFile(std::string text);
 void GenerateCode(std::vector<StatementObject*>* programObj, std::string fileName);
 
@@ -28,12 +32,17 @@ int main_internal(int argc, const char* argv[]) {
 
     ArgsManager::setArgs(argc, argv);
 
+    if (ArgsManager::getFlag("--version") || ArgsManager::getFlag("-v")) {
+        KAPRINO_LOG("kprc - Kaprino Compiler version: " << KAPRINO_VERSION);
+        return 0;
+    }
+
     std::string input_file_path = ArgsManager::getFile();
     std::ifstream input_file(input_file_path);
 
     if (!input_file.good()) {
         KAPRINO_ERR("Not found input files: \"" << ArgsManager::getFile() << "\"");
-        throw - 1;
+        throw -1;
     }
 
     std::ostringstream ss;


### PR DESCRIPTION
You may think why I reduced the size of CMakeLists.txt. That's because the bigger file we have the less we have chance to find bugs.