### PR TITLE
Show various and understandable error messages

### DIFF
--- a/src/kprc/CMakeLists.txt
+++ b/src/kprc/CMakeLists.txt
@@ -9,6 +9,7 @@ set(INTERPRETER_SOURCES
     "${CMAKE_SOURCE_DIR}/src/kprc/DependencySolver.cpp"
     "${CMAKE_SOURCE_DIR}/src/kprc/ExecutableGenerator.cpp"
     "${CMAKE_SOURCE_DIR}/src/kprc/FunctionManager.cpp"
+    "${CMAKE_SOURCE_DIR}/src/kprc/KaprinoErrorListener.cpp"
     "${CMAKE_SOURCE_DIR}/src/kprc/KaprinoParser.impl.cpp"
     "${CMAKE_SOURCE_DIR}/src/kprc/TypeManager.cpp"
     "${CMAKE_SOURCE_DIR}/src/kprc/VariableManager.cpp"

--- a/src/kprc/KaprinoAccelerator.h
+++ b/src/kprc/KaprinoAccelerator.h
@@ -49,6 +49,8 @@
 #   define KAPRINO_LOG_INIT()
 #endif
 
+#define KAPRINO_ASSERT(check, msg, ex) if(!(check)) { KAPRINO_ERR(msg); throw (ex); }
+
 //
 // ------ LLVM type ------
 //

--- a/src/kprc/KaprinoErrorListener.cpp
+++ b/src/kprc/KaprinoErrorListener.cpp
@@ -1,0 +1,8 @@
+#include "KaprinoErrorListener.h"
+
+void KaprinoErrorListener::syntaxError(Recognizer* recognizer, Token* offendingSymbol, size_t line, size_t charPositionInLine,
+    const std::string& msg, std::exception_ptr e)
+{
+    KAPRINO_ERR(msg << " [" << recognizer->getInputStream()->getSourceName() << " line:" << line << " pos:" << charPositionInLine + 1 << "]");
+    throw -1;
+}

--- a/src/kprc/KaprinoErrorListener.cpp
+++ b/src/kprc/KaprinoErrorListener.cpp
@@ -3,6 +3,6 @@
 void KaprinoErrorListener::syntaxError(Recognizer* recognizer, Token* offendingSymbol, size_t line, size_t charPositionInLine,
     const std::string& msg, std::exception_ptr e)
 {
-    KAPRINO_ERR(msg << " [" << recognizer->getInputStream()->getSourceName() << " line:" << line << " pos:" << charPositionInLine + 1 << "]");
+    KAPRINO_ERR(msg << " (" << recognizer->getInputStream()->getSourceName() << " line:" << line << " pos:" << charPositionInLine + 1 << ")");
     throw -1;
 }

--- a/src/kprc/KaprinoErrorListener.h
+++ b/src/kprc/KaprinoErrorListener.h
@@ -1,0 +1,9 @@
+#include "KaprinoAccelerator.h"
+
+using namespace antlr4;
+
+class KaprinoErrorListener : public BaseErrorListener {
+   public:
+    virtual void syntaxError(Recognizer* recognizer, Token* offendingSymbol, size_t line, size_t charPositionInLine,
+        const std::string& msg, std::exception_ptr e) override;
+};

--- a/src/kprc/KaprinoParser.impl.cpp
+++ b/src/kprc/KaprinoParser.impl.cpp
@@ -7,6 +7,7 @@
 #include "ArgsManager.h"
 #include "ExecutableGenerator.h"
 #include "KaprinoAccelerator.h"
+#include "KaprinoErrorListener.h"
 #include "StatementVisitor.h"
 #include "TypeManager.h"
 #include "visitor/statements/StatementObject.h"
@@ -83,6 +84,13 @@ std::vector<StatementObject*>* ParseFile(std::string text) {
     KaprinoLexer lexer(&input);
     CommonTokenStream tokens(&lexer);
     KaprinoParser parser(&tokens);
+    KaprinoErrorListener errorListener;
+
+    lexer.removeErrorListeners();
+    lexer.addErrorListener(&errorListener);
+
+    parser.removeErrorListeners();
+    parser.addErrorListener(&errorListener);
 
     auto program = parser.program();
 

--- a/src/kprc/visitor/statements/AssignStatementVisitor.cpp
+++ b/src/kprc/visitor/statements/AssignStatementVisitor.cpp
@@ -16,6 +16,13 @@ class AssignStatementObject : StatementObject {
     virtual void codegen(llvm::IRBuilder<>* builder, llvm::Module* module) override {
         auto ptr = assignee->codegen(builder, module);
         auto val = expr->codegen(builder, module);
+
+        KAPRINO_ASSERT(
+            ptr->getType()->getPointerTo() == val->getType(),
+            "Types are not matched",
+            1
+        );
+
         builder->CreateStore(val, ptr);
     }
 };

--- a/src/kprc/visitor/statements/LetStatementVisitor.cpp
+++ b/src/kprc/visitor/statements/LetStatementVisitor.cpp
@@ -19,6 +19,13 @@ class LetStatementObject : StatementObject {
         auto allocated = VariableManager::create(builder, module, name, ty);
         if (initVal) {
             auto init_val = initVal->codegen(builder, module);
+
+            KAPRINO_ASSERT (
+                allocated->getType()->getPointerTo() == init_val->getType(),
+                "Types are not matched",
+                1
+            );
+
             builder->CreateStore(init_val, allocated);
         }
     }


### PR DESCRIPTION
Currently, kprc shows error messages only which ANTLR4 generates.
It means, you know, there are no ways to notice errors in your code easily.