### PR TITLE
Remove meaningless unwrap() or match expressions

### DIFF
--- a/src/kgen/src/functions/expr_function.rs
+++ b/src/kgen/src/functions/expr_function.rs
@@ -41,31 +41,26 @@ impl<'ctx> ExprFunction {
     }
 
     pub fn codegen(&self, gen: &CodeGen<'ctx>) -> Result<(), String> {
-        match self.get_func_type(gen) {
-            Ok(func_type) => {
-                let func = gen.module.add_function(&self.get_info().name, func_type, None);
-                let basic_block = gen.context.append_basic_block(func, "entry");
+        let func_type =  self.get_func_type(gen)?;
 
-                gen.builder.position_at_end(basic_block);
+        let func = gen.module.add_function(&self.get_info().name, func_type, None);
+        let basic_block = gen.context.append_basic_block(func, "entry");
 
-                self.assign_args(gen, &func);
+        gen.builder.position_at_end(basic_block);
 
-                match self.expr.codegen(gen) {
-                    Ok(expr) => {
-                        gen.builder.build_return(Some(&expr));
+        self.assign_args(gen, &func);
 
-                        gen.param_resolver.borrow_mut().remove_scope();
+        match self.expr.codegen(gen) {
+            Ok(expr) => {
+                gen.builder.build_return(Some(&expr));
 
-                        Ok(())
-                    },
-                    Err(error_message) => {
-                        gen.param_resolver.borrow_mut().remove_scope();
+                gen.param_resolver.borrow_mut().remove_scope();
 
-                        Err(error_message.to_string())
-                    }
-                }
+                Ok(())
             },
             Err(error_message) => {
+                gen.param_resolver.borrow_mut().remove_scope();
+
                 Err(error_message)
             }
         }

--- a/src/kgen/src/functions/external_function.rs
+++ b/src/kgen/src/functions/external_function.rs
@@ -38,16 +38,11 @@ impl<'ctx> ExternalFunction {
     }
 
     pub fn codegen(&self, gen: &CodeGen<'ctx>) -> Result<(), String> {
-        match self.get_func_type(gen) {
-            Ok(func_type) => {
-                gen.module.add_function(&self.get_info().name, func_type, Some(Linkage::External));
+        let func_type = self.get_func_type(gen)?;
 
-                Ok(())
-            },
-            Err(error_message) => {
-                Err(error_message)
-            }
-        }
+        gen.module.add_function(&self.get_info().name, func_type, Some(Linkage::External));
+
+        Ok(())
     }
 }
 

--- a/src/kgen/src/functions/function_type_object.rs
+++ b/src/kgen/src/functions/function_type_object.rs
@@ -22,10 +22,8 @@ pub fn function_type_parser(text: &str) -> IResult<&str, (Vec<&str>, &str)> {
         )),
         |val| {
             let (_, _, args, _, _, _, ret, _, _) = val;
-            match ret {
-                Some(ret) => (args, ret),
-                None => (args, "")
-            }
+
+            (args, ret.unwrap_or(""))
         }
     )(text)
 }

--- a/src/kgen/src/functions/statement_function.rs
+++ b/src/kgen/src/functions/statement_function.rs
@@ -52,7 +52,7 @@ impl<'ctx> StatementFunction {
                 self.assign_args(gen, &func);
 
                 for st in &self.statements {
-                    st.codegen(gen);
+                    st.codegen(gen)?;
                 };
 
                 gen.param_resolver.borrow_mut().remove_scope();

--- a/src/kgen/src/functions/statement_function.rs
+++ b/src/kgen/src/functions/statement_function.rs
@@ -42,27 +42,22 @@ impl<'ctx> StatementFunction {
     }
 
     pub fn codegen(&self, gen: &CodeGen<'ctx>) -> Result<(), String> {
-        match self.get_func_type(gen) {
-            Ok(func_type) => {
-                let func = gen.module.add_function(&self.get_info().name, func_type, None);
-                let basic_block = gen.context.append_basic_block(func, "entry");
+        let func_type = self.get_func_type(gen)?;
 
-                gen.builder.position_at_end(basic_block);
+        let func = gen.module.add_function(&self.get_info().name, func_type, None);
+        let basic_block = gen.context.append_basic_block(func, "entry");
 
-                self.assign_args(gen, &func);
+        gen.builder.position_at_end(basic_block);
 
-                for st in &self.statements {
-                    st.codegen(gen)?;
-                };
+        self.assign_args(gen, &func);
 
-                gen.param_resolver.borrow_mut().remove_scope();
+        for st in &self.statements {
+            st.codegen(gen)?;
+        };
 
-                Ok(())
-            },
-            Err(error_message) => {
-                Err(error_message)
-            }
-        }
+        gen.param_resolver.borrow_mut().remove_scope();
+
+        Ok(())
     }
 }
 

--- a/src/kgen/src/jit/execute_statement.rs
+++ b/src/kgen/src/jit/execute_statement.rs
@@ -19,7 +19,7 @@ pub fn execute_statement(text: &str) -> Option<u32> {
     gen.builder.position_at_end(basic_block);
 
     if let Ok((_, val)) = statement_parser(text) {
-        val.codegen(&gen);
+        val.codegen(&gen).unwrap();
 
         let execution_engine = gen.module.create_jit_execution_engine(OptimizationLevel::None).unwrap();
 

--- a/src/kgen/src/statements/mod.rs
+++ b/src/kgen/src/statements/mod.rs
@@ -9,11 +9,11 @@ pub enum StatementObject {
 }
 
 impl<'ctx> StatementObject {
-    pub fn codegen(&self, gen: &CodeGen<'ctx>) {
+    pub fn codegen(&self, gen: &CodeGen<'ctx>) -> Result<(), String> {
         match self {
             StatementObject::RetObject(obj) => obj.codegen(gen),
             StatementObject::LetObject(obj) => obj.codegen(gen)
-        };
+        }
     }
 }
 

--- a/src/kgen/src/statements/ret_object.rs
+++ b/src/kgen/src/statements/ret_object.rs
@@ -1,4 +1,3 @@
-use inkwell::values::BasicValueEnum;
 use nom::IResult;
 use nom::sequence::tuple;
 use nom::combinator::map;
@@ -21,24 +20,12 @@ impl<'ctx> RetObject {
         }
     }
 
-    fn get_ret_val(&self, gen: &CodeGen<'ctx>) -> Option<BasicValueEnum<'ctx>> {
-        match self.expr.codegen(gen) {
-            Ok(val) => Some(val),
-            Err(_) => None
-        }
-    }
+    pub fn codegen(&self, gen: &CodeGen<'ctx>) -> Result<(), String> {
+        let ret_val = self.expr.codegen(gen)?;
 
-    pub fn codegen(&self, gen: &CodeGen<'ctx>) {
-        let ret_val = self.get_ret_val(gen);
+        gen.builder.build_return(Some(&ret_val));
 
-        match ret_val {
-            Some(val) => {
-                gen.builder.build_return(Some(&val));
-            },
-            None => {
-                gen.builder.build_return(None);
-            }
-        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Why don't we use syntax sugar?