### PR TITLE
Arrange parser functions

### DIFF
--- a/src/kgen/Cargo.toml
+++ b/src/kgen/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2018"
 
 [dependencies]
 inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm11-0"] }
-lazy_static = "1.4.0"
 regex = "^1.4.3"
-nom = "^6.1.2"
+nom = { version = "^6.1.2", features = ["regexp"] }
 nom-greedyerror = "0.3.1"
 nom_locate = "^3.0.0"

--- a/src/kgen/Cargo.toml
+++ b/src/kgen/Cargo.toml
@@ -11,4 +11,5 @@ inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", feat
 lazy_static = "1.4.0"
 regex = "^1.4.3"
 nom = "^6.1.2"
+nom-greedyerror = "0.3.1"
 nom_locate = "^3.0.0"

--- a/src/kgen/src/lib.rs
+++ b/src/kgen/src/lib.rs
@@ -1,9 +1,8 @@
 extern crate inkwell;
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
-extern crate nom;
+extern crate nom_greedyerror;
 extern crate nom_locate;
+extern crate nom;
+extern crate regex;
 
 pub mod ast;
 pub mod error;

--- a/src/kgen/src/parsers/exprs/exponents_object.rs
+++ b/src/kgen/src/parsers/exprs/exponents_object.rs
@@ -1,13 +1,12 @@
 use nom::character::complete::char;
 use nom::character::complete::multispace0;
 use nom::combinator::opt;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::exponents_object::ExponentsObject;
 use crate::parsers::factors::factor_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse a factor with an exponentiation operator. Can be written in BNF as follow.
@@ -16,7 +15,7 @@ use crate::parsers::utils::get_position;
 /// <factor_with_op> ::= "^" <factor>
 /// ```
 ///
-fn factor_with_op_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+fn factor_with_op_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, _) = char('^')(text)?;
     let (text, _) = multispace0(text)?;
     let (text, factor) = factor_parser(text)?;
@@ -30,7 +29,7 @@ fn factor_with_op_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseEr
 /// <exponents> ::= <factor> ("^" <factor>)*
 /// ```
 ///
-pub fn exponents_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn exponents_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, left_value) = factor_parser(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/exprs/exponents_object.rs
+++ b/src/kgen/src/parsers/exprs/exponents_object.rs
@@ -3,12 +3,11 @@ use nom::character::complete::multispace0;
 use nom::combinator::opt;
 use nom::error::VerboseError;
 use nom::IResult;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::exponents_object::ExponentsObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::factors::factor_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::get_position;
 
 ///
 /// Parse a factor with an exponentiation operator. Can be written in BNF as follow.
@@ -32,11 +31,10 @@ fn factor_with_op_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseEr
 /// ```
 ///
 pub fn exponents_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, left_value) = factor_parser(text)?;
     let (text, _) = multispace0(text)?;
     let (text, right_value) = opt(factor_with_op_parser)(text)?;
-    let pos = FilePosition::from_span("File".to_string(), &pos);
     let obj = match right_value {
         None => {
             left_value

--- a/src/kgen/src/parsers/exprs/exponents_object.rs
+++ b/src/kgen/src/parsers/exprs/exponents_object.rs
@@ -1,5 +1,5 @@
 use nom::character::complete::char;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::combinator::opt;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -19,7 +19,7 @@ use crate::parsers::Span;
 ///
 fn factor_with_op_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
     let (text, _) = char('^')(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, factor) = factor_parser(text)?;
     Ok((text, factor))
 }
@@ -34,7 +34,7 @@ fn factor_with_op_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseEr
 pub fn exponents_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
     let (text, left_value) = factor_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, right_value) = opt(factor_with_op_parser)(text)?;
     let pos = FilePosition::from_span("File".to_string(), &pos);
     let obj = match right_value {

--- a/src/kgen/src/parsers/exprs/mod.rs
+++ b/src/kgen/src/parsers/exprs/mod.rs
@@ -1,14 +1,13 @@
 use nom::branch::alt;
 use nom::character::complete::char;
 use nom::character::complete::multispace0;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::expr_object::{ ExprObject, ExprOpKind };
 use crate::parsers::exprs::term_object::term_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse a term with one operator. Can be written in BNF as follow.
@@ -17,7 +16,7 @@ use crate::parsers::utils::get_position;
 /// <term_with_op> ::= ("+" | "-") <term>
 /// ```
 ///
-fn term_with_op_parser(text: Span) -> IResult<Span, (ExprOpKind, EvaluableObject), VerboseError<Span>> {
+fn term_with_op_parser(text: Span) -> IResult<Span, (ExprOpKind, EvaluableObject), GSError> {
     let (text, op) = alt((char('+'), char('-')))(text)?;
     let (text, _) = multispace0(text)?;
     let (text, term) = term_parser(text)?;
@@ -38,7 +37,7 @@ fn term_with_op_parser(text: Span) -> IResult<Span, (ExprOpKind, EvaluableObject
 /// <expr> ::= <term> (("+" | "-") <term>)*
 /// ```
 ///
-pub fn expr_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn expr_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, left_value) = term_parser(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/exprs/mod.rs
+++ b/src/kgen/src/parsers/exprs/mod.rs
@@ -4,12 +4,11 @@ use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::expr_object::{ ExprObject, ExprOpKind };
-use crate::error::error_token::FilePosition;
 use crate::parsers::exprs::term_object::term_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::get_position;
 
 ///
 /// Parse a term with one operator. Can be written in BNF as follow.
@@ -40,12 +39,10 @@ fn term_with_op_parser(text: Span) -> IResult<Span, (ExprOpKind, EvaluableObject
 /// ```
 ///
 pub fn expr_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, left_value) = term_parser(text)?;
     let (text, _) = multispace0(text)?;
     let (text, right_values) = many0(term_with_op_parser)(text)?;
-
-    let pos = FilePosition::from_span("File".to_string(), &pos);
 
     if right_values.len() == 0 {
         Ok((text, left_value))

--- a/src/kgen/src/parsers/exprs/mod.rs
+++ b/src/kgen/src/parsers/exprs/mod.rs
@@ -1,6 +1,6 @@
 use nom::branch::alt;
 use nom::character::complete::char;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
@@ -20,7 +20,7 @@ use crate::parsers::Span;
 ///
 fn term_with_op_parser(text: Span) -> IResult<Span, (ExprOpKind, EvaluableObject), VerboseError<Span>> {
     let (text, op) = alt((char('+'), char('-')))(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, term) = term_parser(text)?;
 
     let op = match op {
@@ -42,7 +42,7 @@ fn term_with_op_parser(text: Span) -> IResult<Span, (ExprOpKind, EvaluableObject
 pub fn expr_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
     let (text, left_value) = term_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, right_values) = many0(term_with_op_parser)(text)?;
 
     let pos = FilePosition::from_span("File".to_string(), &pos);

--- a/src/kgen/src/parsers/exprs/term_object.rs
+++ b/src/kgen/src/parsers/exprs/term_object.rs
@@ -1,14 +1,13 @@
 use nom::branch::alt;
 use nom::character::complete::char;
 use nom::character::complete::multispace0;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::term_object::{ TermObject, TermOpKind };
 use crate::parsers::exprs::exponents_object::exponents_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse an expression which contains exponentiations with one operator. Can be written in BNF as follow.
@@ -17,7 +16,7 @@ use crate::parsers::utils::get_position;
 /// <exponents_with_op> ::= ("*" | "/") <exponents>
 /// ```
 ///
-fn exponents_with_op_parser(text: Span) -> IResult<Span, (TermOpKind, EvaluableObject), VerboseError<Span>> {
+fn exponents_with_op_parser(text: Span) -> IResult<Span, (TermOpKind, EvaluableObject), GSError> {
     let (text, op) = alt((char('*'), char('/')))(text)?;
     let (text, _) = multispace0(text)?;
     let (text, exp) = exponents_parser(text)?;
@@ -38,7 +37,7 @@ fn exponents_with_op_parser(text: Span) -> IResult<Span, (TermOpKind, EvaluableO
 /// <term> ::= <exponents> (("*" | "/") <exponents>)*
 /// ```
 ///
-pub fn term_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn term_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, left_value) = exponents_parser(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/exprs/term_object.rs
+++ b/src/kgen/src/parsers/exprs/term_object.rs
@@ -4,12 +4,11 @@ use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::term_object::{ TermObject, TermOpKind };
-use crate::error::error_token::FilePosition;
 use crate::parsers::exprs::exponents_object::exponents_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::get_position;
 
 ///
 /// Parse an expression which contains exponentiations with one operator. Can be written in BNF as follow.
@@ -40,12 +39,10 @@ fn exponents_with_op_parser(text: Span) -> IResult<Span, (TermOpKind, EvaluableO
 /// ```
 ///
 pub fn term_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, left_value) = exponents_parser(text)?;
     let (text, _) = multispace0(text)?;
     let (text, right_values) = many0(exponents_with_op_parser)(text)?;
-
-    let pos = FilePosition::from_span("File".to_string(), &pos);
 
     let obj =
         if right_values.len() == 0 {

--- a/src/kgen/src/parsers/exprs/term_object.rs
+++ b/src/kgen/src/parsers/exprs/term_object.rs
@@ -1,6 +1,6 @@
 use nom::branch::alt;
 use nom::character::complete::char;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
@@ -20,7 +20,7 @@ use crate::parsers::Span;
 ///
 fn exponents_with_op_parser(text: Span) -> IResult<Span, (TermOpKind, EvaluableObject), VerboseError<Span>> {
     let (text, op) = alt((char('*'), char('/')))(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, exp) = exponents_parser(text)?;
 
     let op = match op {
@@ -42,7 +42,7 @@ fn exponents_with_op_parser(text: Span) -> IResult<Span, (TermOpKind, EvaluableO
 pub fn term_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
     let (text, left_value) = exponents_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, right_values) = many0(exponents_with_op_parser)(text)?;
 
     let pos = FilePosition::from_span("File".to_string(), &pos);

--- a/src/kgen/src/parsers/factors/function_call_object.rs
+++ b/src/kgen/src/parsers/factors/function_call_object.rs
@@ -1,19 +1,17 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::separated_list0;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::function_call_object::FunctionCallObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::identifier;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ identifier, get_position, GSError };
 
 ///
 /// Parse an expression with spaces.
 ///
-fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, _) = multispace0(text)?;
     let (text, expr) = expr_parser(text)?;
     let (text, _) = multispace0(text)?;
@@ -27,7 +25,7 @@ fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, VerboseError<S
 /// <function_call> ::= .* "(" (<expr> ("," <expr>)*)* ")"
 /// ```
 ///
-pub fn function_call_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn function_call_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, function_name) = identifier(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/factors/function_call_object.rs
+++ b/src/kgen/src/parsers/factors/function_call_object.rs
@@ -1,5 +1,4 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::alphanumeric1;
 use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -10,6 +9,7 @@ use crate::ast::exprs::function_call_object::FunctionCallObject;
 use crate::error::error_token::FilePosition;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::identifier;
 
 ///
 /// Parse an expression with spaces.
@@ -30,7 +30,7 @@ fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, VerboseError<S
 ///
 pub fn function_call_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
-    let (text, function_name) = alphanumeric1(text)?;
+    let (text, function_name) = identifier(text)?;
     let (text, _) = multispace0(text)?;
     let (text, _) = tag("(")(text)?;
     let (text, args) = separated_list0(tag(","), expr_with_spaces)(text)?;

--- a/src/kgen/src/parsers/factors/function_call_object.rs
+++ b/src/kgen/src/parsers/factors/function_call_object.rs
@@ -3,13 +3,12 @@ use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::separated_list0;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::function_call_object::FunctionCallObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
 use crate::parsers::utils::identifier;
+use crate::parsers::utils::get_position;
 
 ///
 /// Parse an expression with spaces.
@@ -29,13 +28,12 @@ fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, VerboseError<S
 /// ```
 ///
 pub fn function_call_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, function_name) = identifier(text)?;
     let (text, _) = multispace0(text)?;
     let (text, _) = tag("(")(text)?;
     let (text, args) = separated_list0(tag(","), expr_with_spaces)(text)?;
     let (text, _) = tag(")")(text)?;
-    let pos = FilePosition::from_span("File".to_string(), &pos);
 
     let obj = EvaluableObject::FunctionCallObject(Box::new(
         FunctionCallObject::new(pos, function_name.to_string(), args)

--- a/src/kgen/src/parsers/factors/function_call_object.rs
+++ b/src/kgen/src/parsers/factors/function_call_object.rs
@@ -1,22 +1,14 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
+use nom::combinator::map;
 use nom::IResult;
 use nom::multi::separated_list0;
+use nom::sequence::tuple;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::function_call_object::FunctionCallObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
 use crate::parsers::utils::{ identifier, get_position, GSError };
-
-///
-/// Parse an expression with spaces.
-///
-fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, GSError> {
-    let (text, _) = multispace0(text)?;
-    let (text, expr) = expr_parser(text)?;
-    let (text, _) = multispace0(text)?;
-    Ok((text, expr))
-}
 
 ///
 /// Parse a factor which calls a function. Can be written in BNF as follow.
@@ -26,6 +18,18 @@ fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, GSError> {
 /// ```
 ///
 pub fn function_call_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
+    let expr_with_spaces =
+        map(
+            tuple((
+                multispace0,
+                expr_parser,
+                multispace0
+            )),
+            |(_, statement, _)| {
+                statement
+            }
+        );
+
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, function_name) = identifier(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/factors/function_call_object.rs
+++ b/src/kgen/src/parsers/factors/function_call_object.rs
@@ -1,6 +1,6 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::alphanumeric1;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::separated_list0;
@@ -15,9 +15,9 @@ use crate::parsers::Span;
 /// Parse an expression with spaces.
 ///
 fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, expr) = expr_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     Ok((text, expr))
 }
 
@@ -31,7 +31,7 @@ fn expr_with_spaces(text: Span) -> IResult<Span, EvaluableObject, VerboseError<S
 pub fn function_call_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
     let (text, function_name) = alphanumeric1(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag("(")(text)?;
     let (text, args) = separated_list0(tag(","), expr_with_spaces)(text)?;
     let (text, _) = tag(")")(text)?;

--- a/src/kgen/src/parsers/factors/mod.rs
+++ b/src/kgen/src/parsers/factors/mod.rs
@@ -1,5 +1,4 @@
 use nom::branch::alt;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::exprs::EvaluableObject;
 use crate::parsers::factors::function_call_object::function_call_parser;
@@ -8,11 +7,12 @@ use crate::parsers::factors::paren_object::paren_parser;
 use crate::parsers::factors::param_object::param_parser;
 use crate::parsers::factors::string_object::string_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::GSError;
 
 ///
 /// Parse a factor into `EvaluableObject`.
 ///
-pub fn factor_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn factor_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     alt((
         function_call_parser,
         numbers_parser,

--- a/src/kgen/src/parsers/factors/numbers_object.rs
+++ b/src/kgen/src/parsers/factors/numbers_object.rs
@@ -1,15 +1,14 @@
 use nom::character::complete::digit1;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::numbers_object::NumberObject;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse a number.
 ///
-pub fn numbers_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn numbers_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, digit) = digit1(text)?;
 

--- a/src/kgen/src/parsers/factors/numbers_object.rs
+++ b/src/kgen/src/parsers/factors/numbers_object.rs
@@ -1,19 +1,17 @@
 use nom::character::complete::digit1;
 use nom::error::VerboseError;
 use nom::IResult;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::numbers_object::NumberObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::Span;
+use crate::parsers::utils::get_position;
 
 ///
 /// Parse a number.
 ///
 pub fn numbers_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, digit) = digit1(text)?;
-    let pos = FilePosition::from_span("file".to_string(), &pos);
 
     let obj = EvaluableObject::NumberObject(
         Box::new(NumberObject::new(

--- a/src/kgen/src/parsers/factors/param_object.rs
+++ b/src/kgen/src/parsers/factors/param_object.rs
@@ -1,14 +1,13 @@
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::param_object::ParamObject;
 use crate::parsers::Span;
-use crate::parsers::utils::{ identifier, get_position };
+use crate::parsers::utils::{ identifier, get_position, GSError };
 
 ///
 /// Parse a parameter.
 ///
-pub fn param_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn param_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, param) = identifier(text)?;
 

--- a/src/kgen/src/parsers/factors/param_object.rs
+++ b/src/kgen/src/parsers/factors/param_object.rs
@@ -1,19 +1,16 @@
 use nom::error::VerboseError;
 use nom::IResult;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::param_object::ParamObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::Span;
-use crate::parsers::utils::identifier;
+use crate::parsers::utils::{ identifier, get_position };
 
 ///
 /// Parse a parameter.
 ///
 pub fn param_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, param) = identifier(text)?;
-    let pos = FilePosition::from_span("File".to_string(), &pos);
 
     let obj = EvaluableObject::ParamObject(Box::new(
             ParamObject::new(pos, param.to_string())

--- a/src/kgen/src/parsers/factors/param_object.rs
+++ b/src/kgen/src/parsers/factors/param_object.rs
@@ -1,4 +1,3 @@
-use nom::character::complete::alphanumeric1;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom_locate::position;
@@ -6,13 +5,14 @@ use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::param_object::ParamObject;
 use crate::error::error_token::FilePosition;
 use crate::parsers::Span;
+use crate::parsers::utils::identifier;
 
 ///
 /// Parse a parameter.
 ///
 pub fn param_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
-    let (text, param) = alphanumeric1(text)?;
+    let (text, param) = identifier(text)?;
     let pos = FilePosition::from_span("File".to_string(), &pos);
 
     let obj = EvaluableObject::ParamObject(Box::new(

--- a/src/kgen/src/parsers/factors/paren_object.rs
+++ b/src/kgen/src/parsers/factors/paren_object.rs
@@ -1,14 +1,14 @@
 use nom::character::complete::char;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::exprs::EvaluableObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::GSError;
 
 ///
 /// Parse an expression which is enclosed in paren.
 ///
-pub fn paren_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn paren_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, _ ) = char('(')(text)?;
     let (text, expr) = expr_parser(text)?;
     let (text, _) = char(')')(text)?;

--- a/src/kgen/src/parsers/factors/string_object.rs
+++ b/src/kgen/src/parsers/factors/string_object.rs
@@ -4,17 +4,16 @@ use nom::character::complete::none_of;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::sequence::delimited;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::string_object::StringObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::Span;
+use crate::parsers::utils::get_position;
 
 ///
 /// Parse an expression which is enclosed in paren.
 ///
 pub fn string_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, val) = delimited(
         tag("\""),
         escaped(
@@ -24,7 +23,6 @@ pub fn string_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<
         ),
         tag("\"")
     )(text)?;
-    let pos = FilePosition::from_span("File".to_string(), &pos);
 
     let obj = EvaluableObject::StringObject(Box::new(
             StringObject::new(pos, val.to_string())

--- a/src/kgen/src/parsers/factors/string_object.rs
+++ b/src/kgen/src/parsers/factors/string_object.rs
@@ -1,18 +1,17 @@
 use nom::bytes::complete::escaped;
 use nom::bytes::complete::tag;
 use nom::character::complete::none_of;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::sequence::delimited;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::exprs::string_object::StringObject;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse an expression which is enclosed in paren.
 ///
-pub fn string_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+pub fn string_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, val) = delimited(
         tag("\""),

--- a/src/kgen/src/parsers/functions/expr_function.rs
+++ b/src/kgen/src/parsers/functions/expr_function.rs
@@ -1,7 +1,6 @@
 use nom::character::complete::char;
 use nom::character::complete::multispace0;
 use nom::combinator::map;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::sequence::tuple;
 use crate::ast::exprs::EvaluableObject;
@@ -12,12 +11,12 @@ use crate::parsers::exprs::expr_parser;
 use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::{ identifier, get_position };
+use crate::parsers::utils::{ identifier, get_position, GSError };
 
 ///
 /// Parse a function which has only one expression.
 ///
-pub fn expr_function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
+pub fn expr_function_parser(text: Span) -> IResult<Span, FunctionObject, GSError> {
     map(
         tuple((
             get_position("File".to_string()),

--- a/src/kgen/src/parsers/functions/expr_function.rs
+++ b/src/kgen/src/parsers/functions/expr_function.rs
@@ -4,7 +4,6 @@ use nom::combinator::map;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::sequence::tuple;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::functions::expr_function::ExprFunction;
 use crate::ast::functions::FunctionObject;
@@ -13,7 +12,7 @@ use crate::parsers::exprs::expr_parser;
 use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::identifier;
+use crate::parsers::utils::{ identifier, get_position };
 
 ///
 /// Parse a function which has only one expression.
@@ -21,7 +20,7 @@ use crate::parsers::utils::identifier;
 pub fn expr_function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
     map(
         tuple((
-            position,
+            get_position("File".to_string()),
             identifier,
             multispace0,
             args_parser,
@@ -32,8 +31,7 @@ pub fn expr_function_parser(text: Span) -> IResult<Span, FunctionObject, Verbose
             multispace0,
             function_type_parser
         )),
-        |(pos, func_name, _, args, _, _, _, expr, _, fn_type): (Span, &str, _, Vec<&str>, _, _, _, EvaluableObject, _, (Vec<&str>, &str))| {
-            let pos = FilePosition::from_span("File".to_string(), &pos);
+        |(pos, func_name, _, args, _, _, _, expr, _, fn_type): (FilePosition, &str, _, Vec<&str>, _, _, _, EvaluableObject, _, (Vec<&str>, &str))| {
             let func_name = func_name.to_string();
             let args: Vec<String> = args.iter().map(|s| { s.to_string() }).collect();
             let (types, ret_type) = fn_type;

--- a/src/kgen/src/parsers/functions/expr_function.rs
+++ b/src/kgen/src/parsers/functions/expr_function.rs
@@ -1,4 +1,3 @@
-use nom::character::complete::alphanumeric1;
 use nom::character::complete::char;
 use nom::character::complete::multispace0;
 use nom::combinator::map;
@@ -14,6 +13,7 @@ use crate::parsers::exprs::expr_parser;
 use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::identifier;
 
 ///
 /// Parse a function which has only one expression.
@@ -22,7 +22,7 @@ pub fn expr_function_parser(text: Span) -> IResult<Span, FunctionObject, Verbose
     map(
         tuple((
             position,
-            alphanumeric1,
+            identifier,
             multispace0,
             args_parser,
             multispace0,
@@ -32,7 +32,7 @@ pub fn expr_function_parser(text: Span) -> IResult<Span, FunctionObject, Verbose
             multispace0,
             function_type_parser
         )),
-        |(pos, func_name, _, args, _, _, _, expr, _, fn_type): (Span, Span, _, Vec<&str>, _, _, _, EvaluableObject, _, (Vec<&str>, &str))| {
+        |(pos, func_name, _, args, _, _, _, expr, _, fn_type): (Span, &str, _, Vec<&str>, _, _, _, EvaluableObject, _, (Vec<&str>, &str))| {
             let pos = FilePosition::from_span("File".to_string(), &pos);
             let func_name = func_name.to_string();
             let args: Vec<String> = args.iter().map(|s| { s.to_string() }).collect();

--- a/src/kgen/src/parsers/functions/expr_function.rs
+++ b/src/kgen/src/parsers/functions/expr_function.rs
@@ -1,6 +1,6 @@
 use nom::character::complete::alphanumeric1;
 use nom::character::complete::char;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::combinator::map;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -23,13 +23,13 @@ pub fn expr_function_parser(text: Span) -> IResult<Span, FunctionObject, Verbose
         tuple((
             position,
             alphanumeric1,
-            space0,
+            multispace0,
             args_parser,
-            space0,
+            multispace0,
             char('='),
-            space0,
+            multispace0,
             expr_parser,
-            space0,
+            multispace0,
             function_type_parser
         )),
         |(pos, func_name, _, args, _, _, _, expr, _, fn_type): (Span, Span, _, Vec<&str>, _, _, _, EvaluableObject, _, (Vec<&str>, &str))| {

--- a/src/kgen/src/parsers/functions/external_function.rs
+++ b/src/kgen/src/parsers/functions/external_function.rs
@@ -1,5 +1,4 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::alphanumeric1;
 use nom::character::complete::multispace0;
 use nom::combinator::map;
 use nom::error::VerboseError;
@@ -12,6 +11,7 @@ use crate::error::error_token::FilePosition;
 use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
+use crate::parsers::utils::identifier;
 
 ///
 /// Parse a function which is declared externally.
@@ -22,7 +22,7 @@ pub fn external_function_parser(text: Span) -> IResult<Span, FunctionObject, Ver
             position,
             tag("#extern"),
             multispace0,
-            alphanumeric1,
+            identifier,
             multispace0,
             args_parser,
             multispace0,

--- a/src/kgen/src/parsers/functions/external_function.rs
+++ b/src/kgen/src/parsers/functions/external_function.rs
@@ -1,6 +1,6 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::alphanumeric1;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::combinator::map;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -21,11 +21,11 @@ pub fn external_function_parser(text: Span) -> IResult<Span, FunctionObject, Ver
         tuple((
             position,
             tag("#extern"),
-            space0,
+            multispace0,
             alphanumeric1,
-            space0,
+            multispace0,
             args_parser,
-            space0,
+            multispace0,
             function_type_parser
         )),
         |(pos, _, _, func_name, _, args, _, fn_type)| {

--- a/src/kgen/src/parsers/functions/external_function.rs
+++ b/src/kgen/src/parsers/functions/external_function.rs
@@ -1,7 +1,6 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
 use nom::combinator::map;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::sequence::tuple;
 use crate::ast::functions::external_function::ExternalFunction;
@@ -9,12 +8,12 @@ use crate::ast::functions::FunctionObject;
 use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::{ identifier, get_position };
+use crate::parsers::utils::{ identifier, get_position, GSError };
 
 ///
 /// Parse a function which is declared externally.
 ///
-pub fn external_function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
+pub fn external_function_parser(text: Span) -> IResult<Span, FunctionObject, GSError> {
     map(
         tuple((
             get_position("File".to_string()),

--- a/src/kgen/src/parsers/functions/external_function.rs
+++ b/src/kgen/src/parsers/functions/external_function.rs
@@ -4,14 +4,12 @@ use nom::combinator::map;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::sequence::tuple;
-use nom_locate::position;
 use crate::ast::functions::external_function::ExternalFunction;
 use crate::ast::functions::FunctionObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::identifier;
+use crate::parsers::utils::{ identifier, get_position };
 
 ///
 /// Parse a function which is declared externally.
@@ -19,7 +17,7 @@ use crate::parsers::utils::identifier;
 pub fn external_function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
     map(
         tuple((
-            position,
+            get_position("File".to_string()),
             tag("#extern"),
             multispace0,
             identifier,
@@ -29,7 +27,6 @@ pub fn external_function_parser(text: Span) -> IResult<Span, FunctionObject, Ver
             function_type_parser
         )),
         |(pos, _, _, func_name, _, args, _, fn_type)| {
-            let pos = FilePosition::from_span("File".to_string(), &pos);
             let func_name = func_name.to_string();
             let args: Vec<String> = args.iter().map(|s| { s.to_string() }).collect();
             let types: Vec<String> = fn_type.0.iter().map(|s| { s.to_string() }).collect();

--- a/src/kgen/src/parsers/functions/external_function.rs
+++ b/src/kgen/src/parsers/functions/external_function.rs
@@ -1,5 +1,6 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
+use nom::character::complete::multispace1;
 use nom::combinator::map;
 use nom::IResult;
 use nom::sequence::tuple;
@@ -18,7 +19,7 @@ pub fn external_function_parser(text: Span) -> IResult<Span, FunctionObject, GSE
         tuple((
             get_position("File".to_string()),
             tag("#extern"),
-            multispace0,
+            multispace1,
             identifier,
             multispace0,
             args_parser,

--- a/src/kgen/src/parsers/functions/mod.rs
+++ b/src/kgen/src/parsers/functions/mod.rs
@@ -3,7 +3,6 @@ use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
 use nom::combinator::map;
 use nom::combinator::opt;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
 use nom::sequence::tuple;
@@ -12,12 +11,12 @@ use crate::parsers::functions::expr_function::expr_function_parser;
 use crate::parsers::functions::external_function::external_function_parser;
 use crate::parsers::functions::statement_function::statement_function_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::identifier;
+use crate::parsers::utils::{ identifier, GSError };
 
 ///
 /// Parse a function into `FunctionObject`.
 ///
-pub fn function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
+pub fn function_parser(text: Span) -> IResult<Span, FunctionObject, GSError> {
     alt((
         expr_function_parser,
         external_function_parser,
@@ -28,7 +27,7 @@ pub fn function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError
 ///
 /// Parse arguments inside paren.
 ///
-pub fn args_inside_parser(text: Span) -> IResult<Span, Vec<&str>, VerboseError<Span>> {
+pub fn args_inside_parser(text: Span) -> IResult<Span, Vec<&str>, GSError> {
     let second_args_parser =
         map(
             tuple((
@@ -66,7 +65,7 @@ pub fn args_inside_parser(text: Span) -> IResult<Span, Vec<&str>, VerboseError<S
 ///
 /// Parse arguments with paren.
 ///
-pub fn args_parser(text: Span) -> IResult<Span, Vec<&str>, VerboseError<Span>> {
+pub fn args_parser(text: Span) -> IResult<Span, Vec<&str>, GSError> {
     map(
         tuple((
             tag("("),
@@ -84,7 +83,7 @@ pub fn args_parser(text: Span) -> IResult<Span, Vec<&str>, VerboseError<Span>> {
 ///
 /// Parse a type annotation for a function.
 ///
-pub fn function_type_parser(text: Span) -> IResult<Span, (Vec<&str>, &str), VerboseError<Span>> {
+pub fn function_type_parser(text: Span) -> IResult<Span, (Vec<&str>, &str), GSError> {
     map(
         tuple((
             tag("("),

--- a/src/kgen/src/parsers/functions/mod.rs
+++ b/src/kgen/src/parsers/functions/mod.rs
@@ -1,7 +1,7 @@
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::alphanumeric1;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::combinator::map;
 use nom::combinator::opt;
 use nom::error::VerboseError;
@@ -32,9 +32,9 @@ pub fn args_inside_parser(text: Span) -> IResult<Span, Vec<&str>, VerboseError<S
     let second_args_parser =
         map(
             tuple((
-                space0,
+                multispace0,
                 tag(","),
-                space0,
+                multispace0,
                 alphanumeric1
             )),
             |(_, _, _, arg): (_, _, _, Span)| {
@@ -70,9 +70,9 @@ pub fn args_parser(text: Span) -> IResult<Span, Vec<&str>, VerboseError<Span>> {
     map(
         tuple((
             tag("("),
-            space0,
+            multispace0,
             args_inside_parser,
-            space0,
+            multispace0,
             tag(")")
         )),
         |(_, _, args, _, _)| {
@@ -88,13 +88,13 @@ pub fn function_type_parser(text: Span) -> IResult<Span, (Vec<&str>, &str), Verb
     map(
         tuple((
             tag("("),
-            space0,
+            multispace0,
             args_inside_parser,
-            space0,
+            multispace0,
             tag("->"),
-            space0,
+            multispace0,
             opt(alphanumeric1),
-            space0,
+            multispace0,
             tag(")")
         )),
         |(_, _, args, _, _, _, ret, _, _): (_, _, Vec<&str>, _, _, _, Option<Span>, _, _)| {

--- a/src/kgen/src/parsers/functions/statement_function.rs
+++ b/src/kgen/src/parsers/functions/statement_function.rs
@@ -1,5 +1,4 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::alphanumeric1;
 use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -13,6 +12,7 @@ use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
 use crate::parsers::statements::statement_parser;
+use crate::parsers::utils::identifier;
 
 ///
 /// Parse a statement enclosed with spaces.
@@ -31,7 +31,7 @@ pub fn statement_function_parser(text: Span) -> IResult<Span, FunctionObject, Ve
     let (text, pos) = position(text)?;
     let (text, _) = tag("#func")(text)?;
     let (text, _) = multispace0(text)?;
-    let (text, function_name) = alphanumeric1(text)?;
+    let (text, function_name) = identifier(text)?;
     let (text, _) = multispace0(text)?;
     let (text, args) = args_parser(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/functions/statement_function.rs
+++ b/src/kgen/src/parsers/functions/statement_function.rs
@@ -1,6 +1,6 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::alphanumeric1;
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
@@ -18,9 +18,9 @@ use crate::parsers::statements::statement_parser;
 /// Parse a statement enclosed with spaces.
 ///
 fn statement_with_spaces_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, statement) = statement_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     Ok((text, statement))
 }
 
@@ -30,13 +30,13 @@ fn statement_with_spaces_parser(text: Span) -> IResult<Span, StatementObject, Ve
 pub fn statement_function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
     let (text, _) = tag("#func")(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, function_name) = alphanumeric1(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, args) = args_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, function_type) = function_type_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag("|>")(text)?;
     let (text, statements) = many0(statement_with_spaces_parser)(text)?;
     let (text, _) = tag("|<")(text)?;

--- a/src/kgen/src/parsers/functions/statement_function.rs
+++ b/src/kgen/src/parsers/functions/statement_function.rs
@@ -3,16 +3,14 @@ use nom::character::complete::multispace0;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
-use nom_locate::position;
 use crate::ast::functions::FunctionObject;
 use crate::ast::functions::statement_function::StatementFunction;
 use crate::ast::statements::StatementObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
 use crate::parsers::statements::statement_parser;
-use crate::parsers::utils::identifier;
+use crate::parsers::utils::{ identifier, get_position };
 
 ///
 /// Parse a statement enclosed with spaces.
@@ -28,7 +26,7 @@ fn statement_with_spaces_parser(text: Span) -> IResult<Span, StatementObject, Ve
 /// Parse a C-like function into `FunctionObject`.
 ///
 pub fn statement_function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#func")(text)?;
     let (text, _) = multispace0(text)?;
     let (text, function_name) = identifier(text)?;
@@ -41,7 +39,6 @@ pub fn statement_function_parser(text: Span) -> IResult<Span, FunctionObject, Ve
     let (text, statements) = many0(statement_with_spaces_parser)(text)?;
     let (text, _) = tag("|<")(text)?;
 
-    let pos = FilePosition::from_span("File".to_string(), &pos);
     let function_name = function_name.to_string();
     let args = args.iter().map(|s| { s.to_string() }).collect();
     let (types, ret_type) = function_type;

--- a/src/kgen/src/parsers/functions/statement_function.rs
+++ b/src/kgen/src/parsers/functions/statement_function.rs
@@ -1,6 +1,5 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
 use crate::ast::functions::FunctionObject;
@@ -10,12 +9,12 @@ use crate::parsers::functions::args_parser;
 use crate::parsers::functions::function_type_parser;
 use crate::parsers::Span;
 use crate::parsers::statements::statement_parser;
-use crate::parsers::utils::{ identifier, get_position };
+use crate::parsers::utils::{ identifier, get_position, GSError };
 
 ///
 /// Parse a statement enclosed with spaces.
 ///
-fn statement_with_spaces_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+fn statement_with_spaces_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let (text, _) = multispace0(text)?;
     let (text, statement) = statement_parser(text)?;
     let (text, _) = multispace0(text)?;
@@ -25,7 +24,7 @@ fn statement_with_spaces_parser(text: Span) -> IResult<Span, StatementObject, Ve
 ///
 /// Parse a C-like function into `FunctionObject`.
 ///
-pub fn statement_function_parser(text: Span) -> IResult<Span, FunctionObject, VerboseError<Span>> {
+pub fn statement_function_parser(text: Span) -> IResult<Span, FunctionObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#func")(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/mod.rs
+++ b/src/kgen/src/parsers/mod.rs
@@ -1,13 +1,13 @@
 use nom::character::complete::multispace0;
 use nom::combinator::eof;
 use nom::combinator::map;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
 use nom::sequence::tuple;
 use nom_locate::LocatedSpan;
 use crate::ast::functions::FunctionObject;
 use crate::parsers::functions::function_parser;
+use crate::parsers::utils::GSError;
 
 ///
 /// A text which stores not only a string object but information.
@@ -17,7 +17,7 @@ pub type Span<'a> = LocatedSpan<&'a str>;
 ///
 /// Parse a whole program.
 ///
-pub fn program_parser(text: Span) -> IResult<Span, Vec<FunctionObject>, VerboseError<Span>> {
+pub fn program_parser(text: Span) -> IResult<Span, Vec<FunctionObject>, GSError> {
     let function_with_space_parser = map(
         tuple((
             multispace0,

--- a/src/kgen/src/parsers/mod.rs
+++ b/src/kgen/src/parsers/mod.rs
@@ -3,6 +3,7 @@ use nom::combinator::eof;
 use nom::combinator::map;
 use nom::IResult;
 use nom::multi::many0;
+use nom::sequence::delimited;
 use nom::sequence::tuple;
 use nom_locate::LocatedSpan;
 use crate::ast::functions::FunctionObject;
@@ -18,16 +19,12 @@ pub type Span<'a> = LocatedSpan<&'a str>;
 /// Parse a whole program.
 ///
 pub fn program_parser(text: Span) -> IResult<Span, Vec<FunctionObject>, GSError> {
-    let function_with_space_parser = map(
-        tuple((
+    let function_with_space_parser =
+        delimited(
             multispace0,
             function_parser,
             multispace0
-        )),
-        |(_, function, _)| {
-            function
-        }
-    );
+        );
 
     map(
         tuple((

--- a/src/kgen/src/parsers/mod.rs
+++ b/src/kgen/src/parsers/mod.rs
@@ -1,4 +1,4 @@
-use nom::character::complete::space0;
+use nom::character::complete::multispace0;
 use nom::combinator::eof;
 use nom::combinator::map;
 use nom::error::VerboseError;
@@ -20,9 +20,9 @@ pub type Span<'a> = LocatedSpan<&'a str>;
 pub fn program_parser(text: Span) -> IResult<Span, Vec<FunctionObject>, VerboseError<Span>> {
     let function_with_space_parser = map(
         tuple((
-            space0,
+            multispace0,
             function_parser,
-            space0
+            multispace0
         )),
         |(_, function, _)| {
             function

--- a/src/kgen/src/parsers/statements/assign_object.rs
+++ b/src/kgen/src/parsers/statements/assign_object.rs
@@ -1,12 +1,11 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::statements::assign_object::AssignObject;
 use crate::ast::statements::StatementObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::{ identifier, get_position };
+use crate::parsers::utils::{ identifier, get_position, GSError };
 
 ///
 /// Parse an assign statement. Can be written in BNF as follow.
@@ -15,7 +14,7 @@ use crate::parsers::utils::{ identifier, get_position };
 /// <assign> ::= .* ":=" <expr>
 /// ```
 ///
-pub fn assign_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn assign_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, param_name) = identifier(text)?;
     let (text, _) = multispace0(text)?;

--- a/src/kgen/src/parsers/statements/break_object.rs
+++ b/src/kgen/src/parsers/statements/break_object.rs
@@ -1,10 +1,9 @@
 use nom::bytes::complete::tag;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::statements::break_object::BreakObject;
 use crate::ast::statements::StatementObject;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse a break statement. Can be written in BNF as follow.
@@ -13,7 +12,7 @@ use crate::parsers::utils::get_position;
 /// <break> ::= "#break"
 /// ```
 ///
-pub fn break_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn break_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#break")(text)?;
     Ok((

--- a/src/kgen/src/parsers/statements/call_object.rs
+++ b/src/kgen/src/parsers/statements/call_object.rs
@@ -1,5 +1,5 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::space1;
+use nom::character::complete::multispace1;
 use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::statements::call_object::CallObject;
@@ -18,7 +18,7 @@ use crate::parsers::utils::get_position;
 pub fn call_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#call")(text)?;
-    let (text, _) = space1(text)?;
+    let (text, _) = multispace1(text)?;
     let (text, expr) = expr_parser(text)?;
     Ok((
         text,

--- a/src/kgen/src/parsers/statements/call_object.rs
+++ b/src/kgen/src/parsers/statements/call_object.rs
@@ -1,12 +1,11 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::statements::call_object::CallObject;
 use crate::ast::statements::StatementObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse a call statement. Can be written in BNF as follow.
@@ -15,7 +14,7 @@ use crate::parsers::utils::get_position;
 /// <call> ::= "#call" <expr>
 /// ```
 ///
-pub fn call_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn call_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#call")(text)?;
     let (text, _) = multispace1(text)?;

--- a/src/kgen/src/parsers/statements/if_object.rs
+++ b/src/kgen/src/parsers/statements/if_object.rs
@@ -19,16 +19,16 @@ use crate::parsers::utils::{ get_position, GSError };
 /// ```
 ///
 pub fn if_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
-    let statement_with_space_parser = map(
-        tuple((
-            multispace0,
-            statement_parser,
-            multispace0
-        )),
-        |(_, statement, _)| {
-            statement
-        }
-    );
+    let statement_with_space_parser =
+        map(
+            tuple((
+                statement_parser,
+                multispace0
+            )),
+            |(statement, _)| {
+                statement
+            }
+        );
 
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#if")(text)?;
@@ -36,6 +36,7 @@ pub fn if_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let (text, expr) = expr_parser(text)?;
     let (text, _) = multispace0(text)?;
     let (text, _) = tag("|>")(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, statements) = many0(statement_with_space_parser)(text)?;
     let (text, _) = tag("|<")(text)?;
     Ok((

--- a/src/kgen/src/parsers/statements/if_object.rs
+++ b/src/kgen/src/parsers/statements/if_object.rs
@@ -1,7 +1,6 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::{ multispace0, multispace1 };
 use nom::combinator::map;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
 use nom::sequence::tuple;
@@ -10,7 +9,7 @@ use crate::ast::statements::StatementObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
 use crate::parsers::statements::statement_parser;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse an if statement. Can be written in BNF as follow.
@@ -19,7 +18,7 @@ use crate::parsers::utils::get_position;
 /// <if> ::= "#if" <expr> "|>" <statements> "<|"
 /// ```
 ///
-pub fn if_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn if_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let statement_with_space_parser = map(
         tuple((
             multispace0,

--- a/src/kgen/src/parsers/statements/if_object.rs
+++ b/src/kgen/src/parsers/statements/if_object.rs
@@ -1,5 +1,5 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::{ space0, space1 };
+use nom::character::complete::{ multispace0, multispace1 };
 use nom::combinator::map;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -22,9 +22,9 @@ use crate::parsers::utils::get_position;
 pub fn if_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
     let statement_with_space_parser = map(
         tuple((
-            space0,
+            multispace0,
             statement_parser,
-            space0
+            multispace0
         )),
         |(_, statement, _)| {
             statement
@@ -33,9 +33,9 @@ pub fn if_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span
 
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#if")(text)?;
-    let (text, _) = space1(text)?;
+    let (text, _) = multispace1(text)?;
     let (text, expr) = expr_parser(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag("|>")(text)?;
     let (text, statements) = many0(statement_with_space_parser)(text)?;
     let (text, _) = tag("|<")(text)?;

--- a/src/kgen/src/parsers/statements/let_object.rs
+++ b/src/kgen/src/parsers/statements/let_object.rs
@@ -4,14 +4,12 @@ use nom::character::complete::multispace1;
 use nom::combinator::opt;
 use nom::error::VerboseError;
 use nom::IResult;
-use nom_locate::position;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::statements::let_object::LetObject;
 use crate::ast::statements::StatementObject;
-use crate::error::error_token::FilePosition;
 use crate::parsers::Span;
 use crate::parsers::exprs::expr_parser;
-use crate::parsers::utils::identifier;
+use crate::parsers::utils::{ identifier, get_position };
 
 ///
 /// Parse an assign object. Can be written in BNF as follow.
@@ -56,13 +54,12 @@ fn type_parser(text: Span) -> IResult<Span, &str, VerboseError<Span>> {
 /// ```
 ///
 pub fn let_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#let")(text)?;
     let (text, _) = multispace1(text)?;
     let (text, param_name) = identifier(text)?;
     let (text, assign) = opt(assign_parser)(text)?;
     let (text, type_name) = type_parser(text)?;
-    let pos = FilePosition::from_span("".to_string(), &pos);
     Ok((
         text,
         StatementObject::LetObject(

--- a/src/kgen/src/parsers/statements/let_object.rs
+++ b/src/kgen/src/parsers/statements/let_object.rs
@@ -1,5 +1,4 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::alphanumeric1;
 use nom::character::complete::multispace0;
 use nom::character::complete::multispace1;
 use nom::combinator::opt;
@@ -12,6 +11,7 @@ use crate::ast::statements::StatementObject;
 use crate::error::error_token::FilePosition;
 use crate::parsers::Span;
 use crate::parsers::exprs::expr_parser;
+use crate::parsers::utils::identifier;
 
 ///
 /// Parse an assign object. Can be written in BNF as follow.
@@ -41,11 +41,11 @@ fn type_parser(text: Span) -> IResult<Span, &str, VerboseError<Span>> {
     let (text, _) = multispace0(text)?;
     let (text, _) = tag("<-")(text)?;
     let (text, _) = multispace0(text)?;
-    let (text, type_name) = alphanumeric1(text)?;
+    let (text, type_name) = identifier(text)?;
     let (text, _) = multispace0(text)?;
     let (text, _) = tag(")")(text)?;
     let (text, _) = multispace0(text)?;
-    Ok((text, type_name.fragment()))
+    Ok((text, type_name))
 }
 
 ///
@@ -59,7 +59,7 @@ pub fn let_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Spa
     let (text, pos) = position(text)?;
     let (text, _) = tag("#let")(text)?;
     let (text, _) = multispace1(text)?;
-    let (text, param_name) = alphanumeric1(text)?;
+    let (text, param_name) = identifier(text)?;
     let (text, assign) = opt(assign_parser)(text)?;
     let (text, type_name) = type_parser(text)?;
     let pos = FilePosition::from_span("".to_string(), &pos);

--- a/src/kgen/src/parsers/statements/let_object.rs
+++ b/src/kgen/src/parsers/statements/let_object.rs
@@ -1,7 +1,7 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::alphanumeric1;
-use nom::character::complete::space0;
-use nom::character::complete::space1;
+use nom::character::complete::multispace0;
+use nom::character::complete::multispace1;
 use nom::combinator::opt;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -21,9 +21,9 @@ use crate::parsers::exprs::expr_parser;
 /// ```
 ///
 fn assign_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag(":=")(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, expr) = expr_parser(text)?;
     Ok((text, expr))
 }
@@ -36,15 +36,15 @@ fn assign_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span
 /// ```
 ///
 fn type_parser(text: Span) -> IResult<Span, &str, VerboseError<Span>> {
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag("(")(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag("<-")(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, type_name) = alphanumeric1(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag(")")(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     Ok((text, type_name.fragment()))
 }
 
@@ -58,7 +58,7 @@ fn type_parser(text: Span) -> IResult<Span, &str, VerboseError<Span>> {
 pub fn let_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
     let (text, _) = tag("#let")(text)?;
-    let (text, _) = space1(text)?;
+    let (text, _) = multispace1(text)?;
     let (text, param_name) = alphanumeric1(text)?;
     let (text, assign) = opt(assign_parser)(text)?;
     let (text, type_name) = type_parser(text)?;

--- a/src/kgen/src/parsers/statements/let_object.rs
+++ b/src/kgen/src/parsers/statements/let_object.rs
@@ -2,14 +2,13 @@ use nom::bytes::complete::tag;
 use nom::character::complete::multispace0;
 use nom::character::complete::multispace1;
 use nom::combinator::opt;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::exprs::EvaluableObject;
 use crate::ast::statements::let_object::LetObject;
 use crate::ast::statements::StatementObject;
 use crate::parsers::Span;
 use crate::parsers::exprs::expr_parser;
-use crate::parsers::utils::{ identifier, get_position };
+use crate::parsers::utils::{ identifier, get_position, GSError };
 
 ///
 /// Parse an assign object. Can be written in BNF as follow.
@@ -18,7 +17,7 @@ use crate::parsers::utils::{ identifier, get_position };
 /// <assign> ::= ":=" <expr>
 /// ```
 ///
-fn assign_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span>> {
+fn assign_parser(text: Span) -> IResult<Span, EvaluableObject, GSError> {
     let (text, _) = multispace0(text)?;
     let (text, _) = tag(":=")(text)?;
     let (text, _) = multispace0(text)?;
@@ -33,7 +32,7 @@ fn assign_parser(text: Span) -> IResult<Span, EvaluableObject, VerboseError<Span
 /// <type> ::= "(" "<-" .* ")"
 /// ```
 ///
-fn type_parser(text: Span) -> IResult<Span, &str, VerboseError<Span>> {
+fn type_parser(text: Span) -> IResult<Span, &str, GSError> {
     let (text, _) = multispace0(text)?;
     let (text, _) = tag("(")(text)?;
     let (text, _) = multispace0(text)?;
@@ -53,7 +52,7 @@ fn type_parser(text: Span) -> IResult<Span, &str, VerboseError<Span>> {
 /// <let> ::= "#let" .* (":=" <expr>)* "(" "<-"" .* ")"
 /// ```
 ///
-pub fn let_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn let_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#let")(text)?;
     let (text, _) = multispace1(text)?;

--- a/src/kgen/src/parsers/statements/loop_object.rs
+++ b/src/kgen/src/parsers/statements/loop_object.rs
@@ -1,7 +1,6 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::{ multispace0 };
 use nom::combinator::map;
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::multi::many0;
 use nom::sequence::tuple;
@@ -9,7 +8,7 @@ use crate::ast::statements::loop_object::LoopObject;
 use crate::ast::statements::StatementObject;
 use crate::parsers::Span;
 use crate::parsers::statements::statement_parser;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse a loop statement. Can be written in BNF as follow.
@@ -18,7 +17,7 @@ use crate::parsers::utils::get_position;
 /// <loop> ::= "#loop" "|>" <statements> "<|"
 /// ```
 ///
-pub fn loop_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn loop_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let statement_with_space_parser = map(
         tuple((
             multispace0,

--- a/src/kgen/src/parsers/statements/loop_object.rs
+++ b/src/kgen/src/parsers/statements/loop_object.rs
@@ -1,5 +1,5 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::{ space0 };
+use nom::character::complete::{ multispace0 };
 use nom::combinator::map;
 use nom::error::VerboseError;
 use nom::IResult;
@@ -21,9 +21,9 @@ use crate::parsers::utils::get_position;
 pub fn loop_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
     let statement_with_space_parser = map(
         tuple((
-            space0,
+            multispace0,
             statement_parser,
-            space0
+            multispace0
         )),
         |(_, statement, _)| {
             statement
@@ -32,7 +32,7 @@ pub fn loop_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Sp
 
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#loop")(text)?;
-    let (text, _) = space0(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, _) = tag("|>")(text)?;
     let (text, statements) = many0(statement_with_space_parser)(text)?;
     let (text, _) = tag("|<")(text)?;

--- a/src/kgen/src/parsers/statements/loop_object.rs
+++ b/src/kgen/src/parsers/statements/loop_object.rs
@@ -18,21 +18,22 @@ use crate::parsers::utils::{ get_position, GSError };
 /// ```
 ///
 pub fn loop_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
-    let statement_with_space_parser = map(
-        tuple((
-            multispace0,
-            statement_parser,
-            multispace0
-        )),
-        |(_, statement, _)| {
-            statement
-        }
-    );
+    let statement_with_space_parser =
+        map(
+            tuple((
+                statement_parser,
+                multispace0
+            )),
+            |(statement, _)| {
+                statement
+            }
+        );
 
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#loop")(text)?;
     let (text, _) = multispace0(text)?;
     let (text, _) = tag("|>")(text)?;
+    let (text, _) = multispace0(text)?;
     let (text, statements) = many0(statement_with_space_parser)(text)?;
     let (text, _) = tag("|<")(text)?;
     Ok((

--- a/src/kgen/src/parsers/statements/mod.rs
+++ b/src/kgen/src/parsers/statements/mod.rs
@@ -1,4 +1,3 @@
-use nom::error::VerboseError;
 use nom::IResult;
 use nom::branch::alt;
 use crate::ast::statements::StatementObject;
@@ -10,11 +9,12 @@ use crate::parsers::statements::if_object::if_parser;
 use crate::parsers::statements::let_object::let_parser;
 use crate::parsers::statements::loop_object::loop_parser;
 use crate::parsers::statements::ret_object::ret_parser;
+use crate::parsers::utils::GSError;
 
 ///
 /// Parse a statement into `StatementObject`.
 ///
-pub fn statement_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn statement_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     alt((
         assign_parser,
         break_parser,

--- a/src/kgen/src/parsers/statements/ret_object.rs
+++ b/src/kgen/src/parsers/statements/ret_object.rs
@@ -1,12 +1,11 @@
 use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
-use nom::error::VerboseError;
 use nom::IResult;
 use crate::ast::statements::ret_object::RetObject;
 use crate::ast::statements::StatementObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
-use crate::parsers::utils::get_position;
+use crate::parsers::utils::{ get_position, GSError };
 
 ///
 /// Parse a ret statement.  Can be written in BNF as follow.
@@ -15,7 +14,7 @@ use crate::parsers::utils::get_position;
 /// <ret> ::= "#ret" <expr>"
 /// ```
 ///
-pub fn ret_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
+pub fn ret_parser(text: Span) -> IResult<Span, StatementObject, GSError> {
     let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#ret")(text)?;
     let (text, _) = multispace1(text)?;

--- a/src/kgen/src/parsers/statements/ret_object.rs
+++ b/src/kgen/src/parsers/statements/ret_object.rs
@@ -2,12 +2,11 @@ use nom::bytes::complete::tag;
 use nom::character::complete::multispace1;
 use nom::error::VerboseError;
 use nom::IResult;
-use nom_locate::position;
 use crate::ast::statements::ret_object::RetObject;
 use crate::ast::statements::StatementObject;
 use crate::parsers::exprs::expr_parser;
 use crate::parsers::Span;
-use crate::error::error_token::FilePosition;
+use crate::parsers::utils::get_position;
 
 ///
 /// Parse a ret statement.  Can be written in BNF as follow.
@@ -17,11 +16,10 @@ use crate::error::error_token::FilePosition;
 /// ```
 ///
 pub fn ret_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
-    let (text, pos) = position(text)?;
+    let (text, pos) = get_position("File".to_string())(text)?;
     let (text, _) = tag("#ret")(text)?;
     let (text, _) = multispace1(text)?;
     let (text, expr) = expr_parser(text)?;
-    let pos = FilePosition::from_span("File".to_string(), &pos);
     Ok((
         text,
         StatementObject::RetObject(Box::new(

--- a/src/kgen/src/parsers/statements/ret_object.rs
+++ b/src/kgen/src/parsers/statements/ret_object.rs
@@ -1,5 +1,5 @@
 use nom::bytes::complete::tag;
-use nom::character::complete::space1;
+use nom::character::complete::multispace1;
 use nom::error::VerboseError;
 use nom::IResult;
 use nom_locate::position;
@@ -19,7 +19,7 @@ use crate::error::error_token::FilePosition;
 pub fn ret_parser(text: Span) -> IResult<Span, StatementObject, VerboseError<Span>> {
     let (text, pos) = position(text)?;
     let (text, _) = tag("#ret")(text)?;
-    let (text, _) = space1(text)?;
+    let (text, _) = multispace1(text)?;
     let (text, expr) = expr_parser(text)?;
     let pos = FilePosition::from_span("File".to_string(), &pos);
     Ok((

--- a/src/kgen/src/parsers/utils/mod.rs
+++ b/src/kgen/src/parsers/utils/mod.rs
@@ -1,9 +1,17 @@
 use nom::{ IResult, Slice };
-use nom::error::{ ErrorKind, ParseError, VerboseError };
+use nom::error::{ ErrorKind, ParseError };
 use nom_locate::position;
+use nom_greedyerror::GreedyError;
 use regex::Regex;
 use crate::error::error_token::FilePosition;
 use crate::parsers::Span;
+
+///
+/// `GSError` is an initial of Greedy Span Error. Can be used for tracking an error with `alt` correctly.
+///
+/// For more information, please refer [nom-greedyerror](https://github.com/dalance/nom-greedyerror), an awesome project.
+///
+pub type GSError<'a> = GreedyError<Span<'a>, ErrorKind>;
 
 lazy_static! {
     ///
@@ -17,7 +25,7 @@ lazy_static! {
 ///
 /// Parse a word which is valid for the identifiers of kaprino.
 ///
-pub fn identifier(content: Span) -> IResult<Span, &str, VerboseError<Span>> {
+pub fn identifier(content: Span) -> IResult<Span, &str, GSError> {
     let matched = IDENTIFIER_REGEX
         .captures(content.fragment())
         .ok_or(nom::Err::Error(ParseError::from_error_kind(content, ErrorKind::RegexpCapture)))?;
@@ -33,7 +41,7 @@ pub fn identifier(content: Span) -> IResult<Span, &str, VerboseError<Span>> {
 ///
 /// Never forget to give a file name before calling this function.
 ///
-pub fn get_position(file_name: String) -> impl Fn(Span) -> IResult<Span, FilePosition, VerboseError<Span>> {
+pub fn get_position(file_name: String) -> impl Fn(Span) -> IResult<Span, FilePosition, GSError> {
     move |input| {
         let (input, pos) = position(input)?;
         let pos = FilePosition::from_span(file_name.clone(), &pos);

--- a/src/kgen/src/parsers/utils/mod.rs
+++ b/src/kgen/src/parsers/utils/mod.rs
@@ -1,5 +1,6 @@
 use nom::{ IResult, Slice };
 use nom::error::{ ErrorKind, ParseError };
+use nom::regexp::str::re_capture;
 use nom_locate::position;
 use nom_greedyerror::GreedyError;
 use regex::Regex;
@@ -13,27 +14,24 @@ use crate::parsers::Span;
 ///
 pub type GSError<'a> = GreedyError<Span<'a>, ErrorKind>;
 
-lazy_static! {
-    ///
-    /// A regex expression for specifying identifiers.
-    ///
-    pub static ref IDENTIFIER_REGEX: Regex = {
-        Regex::new(r"[a-zA-Z_]([a-zA-Z0-9_])*(!)*").unwrap()
-    };
-}
-
 ///
 /// Parse a word which is valid for the identifiers of kaprino.
 ///
 pub fn identifier(content: Span) -> IResult<Span, &str, GSError> {
-    let matched = IDENTIFIER_REGEX
-        .captures(content.fragment())
-        .ok_or(nom::Err::Error(ParseError::from_error_kind(content, ErrorKind::RegexpCapture)))?;
+    let regex = Regex::new(r"^[a-zA-Z_]([a-zA-Z0-9_])*(!)*");
 
-    let matched = matched.get(0).map_or("", |s| s.as_str());
-    assert_ne!(matched, "");
+    assert!(regex.is_ok());
 
-    Ok((content.slice(matched.len()..), matched))
+    let (_, parsed) = re_capture::<(&str, ErrorKind)>(regex.unwrap())
+        (content.fragment())
+        .map_err(|_| {
+            nom::Err::Error(ParseError::from_error_kind(content, ErrorKind::RegexpCapture))
+        })?;
+
+    assert_ne!(parsed.len(), 0);
+
+    let parsed = parsed[0];
+    Ok((content.slice(parsed.len()..), parsed))
 }
 
 ///

--- a/src/kgen/src/parsers/utils/mod.rs
+++ b/src/kgen/src/parsers/utils/mod.rs
@@ -61,12 +61,8 @@ mod test {
             let val = Span::new(name);
             let val = identifier(val);
 
-            if let Ok((_, parsed)) = val {
-                assert_eq!(parsed, name);
-            }
-            else {
-                panic!();
-            }
+            assert!(val.is_ok());
+            assert_eq!(val.unwrap().1, name);
         }
     }
 
@@ -79,9 +75,7 @@ mod test {
             let val = Span::new(name);
             let val = identifier(val);
 
-            if let Ok((_, _)) = val {
-                panic!();
-            }
+            assert!(val.is_err());
         }
     }
 }

--- a/src/kpr/src/kprc/mod.rs
+++ b/src/kpr/src/kprc/mod.rs
@@ -127,12 +127,8 @@ impl KprcApp {
         let gen = CodeGen::new(context, &self.source_file);
 
         println!("log: Loading \"{}\"...", self.source_file);
-        let mut content = self.get_source_content()?;
 
-        content = content.replace("\r", "");
-        content = content.replace("\n", "");
-        content = content.replace("\t", "");
-
+        let content = self.get_source_content()?;
         let output_path = self.get_output_path();
 
         println!("log: Parsing \"{}\"...", self.source_file);


### PR DESCRIPTION
This PR is to organize parser functions by unifying the same processes of the functions which consist parser into some utilities.
I think this idea supports object-oriented programming, and it also improves the maintainability. It's just like "Divide and rule."